### PR TITLE
Update plugin descriptor metadata.

### DIFF
--- a/AutoTestGrailsPlugin.groovy
+++ b/AutoTestGrailsPlugin.groovy
@@ -10,10 +10,13 @@ class AutoTestGrailsPlugin {
     def author = "Bjoern Wilmsmann, Mike Hugo"
     def authorEmail = "bjoern@metasieve.com, mike@piragua.com"
     def title = "Auto test plugin"
-    def description = '''\\
-Auto test plugin.
+    def description = '''\
+Provides continuous testing for your Grails projects. Run a single command and then every time you save a file,\
+the relevant tests will run. Great for instant feedback while you're coding.\
 '''
 
     def documentation = "http://grails.org/plugin/auto-test"
-
+    def license = "APACHE"
+    def scm = [url: "https://github.com/mjhugo/grails-auto-test"]
+    def issueManagement = [system: "JIRA", url: "http://jira.grails.org/browse/GPAUTOTEST"]
 }


### PR DESCRIPTION
These changes ensure that the appropriate links are added in the plugin portal. Hope the license is correct (Apache 2)! It would be good to use the `developers` property too, but the portal doesn't display multiple authors yet so leaving as is.
